### PR TITLE
fix(argcount) fix n if too low

### DIFF
--- a/spec/say_spec.lua
+++ b/spec/say_spec.lua
@@ -57,4 +57,11 @@ describe("Tests to make sure the say library is functional", function()
     assert(s('this does not exist') == nil)
   end)
 
+  it("tests the wrong arg count", function()
+    -- backward compatibility after the nil-safe fix, in which the 'n' field got precendence over #
+    s:set('substitute_test', '1 = %s, 2 = %s')
+    -- two arguments, but "n = 1"
+    assert(s('substitute_test', {"one", "two", n = 1}) == '1 = one, 2 = two')
+  end)
+
 end)

--- a/src/say/init.lua
+++ b/src/say/init.lua
@@ -35,6 +35,7 @@ local __meta = {
       error(("expected parameter table to be a table, got '%s'"):format(type(vars)), 2)
     end
     vars = vars or {}
+    vars.n = math.max((vars.n or 0), #vars)
 
     local str = registry[current_namespace][key] or registry[fallback_namespace][key]
 


### PR DESCRIPTION
With Luassert, an assertion is responsible for passing the args
to 'say'. The args table is often passed along from the internal
luassert one to 'say'. If, for some messages, an extra argument is
inserted, and the assertion does not increase the existing 'n' field
on that table, then 'say' will use 'n' and be one argument short.

This is an urgent fix, since it broke some CI. Busted doesn't have the say version pinned, so even older versions of Busted will install the recently released version and will break.